### PR TITLE
API changed and added data that was causing the chart counts to not b…

### DIFF
--- a/Notebooks/COVID19API_DataVis2_CV.ipynb
+++ b/Notebooks/COVID19API_DataVis2_CV.ipynb
@@ -47,10 +47,10 @@
       "metadata": {
         "id": "PGUmewfUtjxw",
         "colab_type": "code",
-        "outputId": "bfdfa94d-aea7-4d19-e564-1976b8c87b40",
+        "outputId": "ec035cfa-1bca-43fe-f188-aed5aa626f5a",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 223
+          "height": 237
         }
       },
       "source": [
@@ -68,13 +68,13 @@
         "# show the data frame with headers.\n",
         "covid_countryindividual.head()"
       ],
-      "execution_count": 4,
+      "execution_count": 2,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
             "200\n",
-            "(123207, 10)\n"
+            "(137731, 10)\n"
           ],
           "name": "stdout"
         },
@@ -196,7 +196,7 @@
           "metadata": {
             "tags": []
           },
-          "execution_count": 4
+          "execution_count": 2
         }
       ]
     },
@@ -205,10 +205,10 @@
       "metadata": {
         "id": "jdlwlnWopB_d",
         "colab_type": "code",
-        "outputId": "9397555d-8b33-4c6d-dfb5-ca9435003b52",
+        "outputId": "51beceb5-a35e-4dfb-9029-4e54bd307fdc",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 207
+          "height": 220
         }
       },
       "source": [
@@ -219,12 +219,12 @@
         "# show the data frame with headers.\n",
         "df.head()"
       ],
-      "execution_count": 5,
+      "execution_count": 3,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
-            "(123207, 10)\n"
+            "(137731, 10)\n"
           ],
           "name": "stdout"
         },
@@ -346,7 +346,7 @@
           "metadata": {
             "tags": []
           },
-          "execution_count": 5
+          "execution_count": 3
         }
       ]
     },
@@ -366,7 +366,9 @@
         "df['Date'] = df['Date'].str.replace(r'T00:00:00Z', '').astype(object)\n",
         "# change the data types of Lat & Lon to floats.\n",
         "df = df.astype({'Lat': float})\n",
-        "df = df.astype({'Lon': float})"
+        "df = df.astype({'Lon': float})\n",
+        "\n",
+        "df = df.drop(df[(df.Country == 'United States of America') & (df.Province == '')].index)"
       ],
       "execution_count": 0,
       "outputs": []
@@ -376,10 +378,10 @@
       "metadata": {
         "id": "vAIMRVtCaSHs",
         "colab_type": "code",
-        "outputId": "55146698-4b2f-4fe8-81c9-323b7927c2a8",
+        "outputId": "673b8d66-facf-46e1-fa8e-996a471b6459",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 207
+          "height": 220
         }
       },
       "source": [
@@ -390,12 +392,12 @@
         "# show the data frame with headers.\n",
         "df.head()"
       ],
-      "execution_count": 7,
+      "execution_count": 5,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
-            "(121883, 10)\n"
+            "(136155, 10)\n"
           ],
           "name": "stdout"
         },
@@ -435,32 +437,6 @@
               "  </thead>\n",
               "  <tbody>\n",
               "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>United States of America</td>\n",
-              "      <td>US</td>\n",
-              "      <td></td>\n",
-              "      <td></td>\n",
-              "      <td></td>\n",
-              "      <td>37.09</td>\n",
-              "      <td>-95.71</td>\n",
-              "      <td>1</td>\n",
-              "      <td>confirmed</td>\n",
-              "      <td>2020-01-22</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>United States of America</td>\n",
-              "      <td>US</td>\n",
-              "      <td></td>\n",
-              "      <td></td>\n",
-              "      <td></td>\n",
-              "      <td>37.09</td>\n",
-              "      <td>-95.71</td>\n",
-              "      <td>1</td>\n",
-              "      <td>confirmed</td>\n",
-              "      <td>2020-01-23</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
               "      <th>2</th>\n",
               "      <td>United States of America</td>\n",
               "      <td>US</td>\n",
@@ -487,17 +463,43 @@
               "      <td>2020-01-24</td>\n",
               "    </tr>\n",
               "    <tr>\n",
-              "      <th>4</th>\n",
+              "      <th>5</th>\n",
               "      <td>United States of America</td>\n",
               "      <td>US</td>\n",
-              "      <td></td>\n",
-              "      <td></td>\n",
-              "      <td></td>\n",
-              "      <td>37.09</td>\n",
-              "      <td>-95.71</td>\n",
-              "      <td>2</td>\n",
+              "      <td>Illinois</td>\n",
+              "      <td>Cook</td>\n",
+              "      <td>17031</td>\n",
+              "      <td>41.84</td>\n",
+              "      <td>-87.82</td>\n",
+              "      <td>1</td>\n",
               "      <td>confirmed</td>\n",
               "      <td>2020-01-24</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>6</th>\n",
+              "      <td>United States of America</td>\n",
+              "      <td>US</td>\n",
+              "      <td>Illinois</td>\n",
+              "      <td>Cook</td>\n",
+              "      <td>17031</td>\n",
+              "      <td>41.84</td>\n",
+              "      <td>-87.82</td>\n",
+              "      <td>1</td>\n",
+              "      <td>confirmed</td>\n",
+              "      <td>2020-01-25</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>8</th>\n",
+              "      <td>United States of America</td>\n",
+              "      <td>US</td>\n",
+              "      <td>Washington</td>\n",
+              "      <td>King</td>\n",
+              "      <td>53033</td>\n",
+              "      <td>47.49</td>\n",
+              "      <td>-121.83</td>\n",
+              "      <td>1</td>\n",
+              "      <td>confirmed</td>\n",
+              "      <td>2020-01-25</td>\n",
               "    </tr>\n",
               "  </tbody>\n",
               "</table>\n",
@@ -505,11 +507,11 @@
             ],
             "text/plain": [
               "                    Country CountryCode  ...     Status        Date\n",
-              "0  United States of America          US  ...  confirmed  2020-01-22\n",
-              "1  United States of America          US  ...  confirmed  2020-01-23\n",
               "2  United States of America          US  ...  confirmed  2020-01-23\n",
               "3  United States of America          US  ...  confirmed  2020-01-24\n",
-              "4  United States of America          US  ...  confirmed  2020-01-24\n",
+              "5  United States of America          US  ...  confirmed  2020-01-24\n",
+              "6  United States of America          US  ...  confirmed  2020-01-25\n",
+              "8  United States of America          US  ...  confirmed  2020-01-25\n",
               "\n",
               "[5 rows x 10 columns]"
             ]
@@ -517,7 +519,7 @@
           "metadata": {
             "tags": []
           },
-          "execution_count": 7
+          "execution_count": 5
         }
       ]
     },


### PR DESCRIPTION
## Trello 
https://trello.com/c/fs5oT8hn

## Description
The API for the heatmap had added a blank province for the USA which had messed with the counts so they were not correct for the graph.  This is now resolved and viewable in the notebook.

Fixes # (issue)
Counts for the USA data were incorrect causing heatmap to not display properly.

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Change Status
- [x] Complete, tested, ready to review, and merge.
